### PR TITLE
Reconnect to the Slack websocket on disconnection

### DIFF
--- a/charlesbot/slack/slack_connection.py
+++ b/charlesbot/slack/slack_connection.py
@@ -43,6 +43,12 @@ class SlackConnection(Borg):
             for msg in messages:
                 message_object = self.get_message_type(msg)
                 return_messages.append(message_object)
+        except TimeoutError as t:
+            self.log.error("Error reading from slack socket: %s" % t)
+            self.log.error("--- full stack trace ---")
+            self.log.error(traceback.format_exc())
+            self.log.info("Now attempting to reconnect")
+            self.connect()
         except BrokenPipeError as b:
             self.log.critical("Error reading from slack socket: %s" % b)
             self.log.critical("--- full stack trace ---")


### PR DESCRIPTION
This ended up being a nasty bug that was hard to reproduce. The error logs looked something like:

```
2015-09-24 07:58:02,432: ERROR [asyncio:1008] Task exception was never retrieved
future: <Task finished coro=<produce() done, defined at /src/env/lib/python3.4/site-packages/charlesbot/robot.py:28> exception=TimeoutError(110, 'Connection timed out')>
Traceback (most recent call last):
  File "/usr/lib/python3.4/asyncio/tasks.py", line 238, in _step
    result = next(coro)
  File "/src/env/lib/python3.4/site-packages/charlesbot/robot.py", line 31, in produce
    yield from self.route_message_to_plugin()
  File "/src/env/lib/python3.4/site-packages/charlesbot/robot.py", line 36, in route_message_to_plugin
    messages = self.sc.rtm_read()
  File "/src/env/lib/python3.4/site-packages/slackclient/_client.py", line 27, in rtm_read
    json_data = self.server.websocket_safe_read()
  File "/src/env/lib/python3.4/site-packages/slackclient/_server.py", line 109, in websocket_safe_read
    data += "{}\n".format(self.websocket.recv())
  File "/src/env/lib/python3.4/site-packages/websocket/_core.py", line 348, in recv
    opcode, data = self.recv_data()
  File "/src/env/lib/python3.4/site-packages/websocket/_core.py", line 365, in recv_data
    opcode, frame = self.recv_data_frame(control_frame)
  File "/src/env/lib/python3.4/site-packages/websocket/_core.py", line 378, in recv_data_frame
    frame = self.recv_frame()
  File "/src/env/lib/python3.4/site-packages/websocket/_core.py", line 410, in recv_frame
    return self.frame_buffer.recv_frame()
  File "/src/env/lib/python3.4/site-packages/websocket/_abnf.py", line 300, in recv_frame
    self.recv_header()
  File "/src/env/lib/python3.4/site-packages/websocket/_abnf.py", line 249, in recv_header
    header = self.recv_strict(2)
  File "/src/env/lib/python3.4/site-packages/websocket/_abnf.py", line 334, in recv_strict
    bytes = self.recv(min(16384, shortage))
  File "/src/env/lib/python3.4/site-packages/websocket/_core.py", line 476, in _recv
    return recv(self.sock, bufsize)
  File "/src/env/lib/python3.4/site-packages/websocket/_socket.py", line 77, in recv
    bytes = sock.recv(bufsize)
  File "/usr/lib/python3.4/ssl.py", line 736, in recv
    return self.read(buflen)
  File "/usr/lib/python3.4/ssl.py", line 625, in read
    v = self._sslobj.read(len or 1024)
TimeoutError: [Errno 110] Connection timed out
```

A bit of research then led me to this PR https://github.com/slackhq/python-slackclient/pull/28